### PR TITLE
Fix format error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format:
-	black *.py
+	black src/ tests/
 
 lint:
 	pylint --disable=R,C src/

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,9 @@
 # Dummy python script to pass linting
 
+
 def main():
     print("Hello, world!")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,11 @@
 import unittest
 from src.main import main
 
+
 class TestMain(unittest.TestCase):
     def test_main(self):
         self.assertIsNone(main())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #4

Format the code using `black` to fix lint errors.

* **src/main.py**
  - Format the code using `black`.

* **tests/test_main.py**
  - Format the code using `black`.

* **Makefile**
  - Update the `format` target to run `black src/ tests/` instead of `black *.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JonathanWamsley/indeed-data-job-scraper/issues/4?shareId=88a581de-987e-4c16-8bd4-65aaa3751006).